### PR TITLE
pkg/util: add annotations support

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -52,28 +52,6 @@
   version = "v1.12.63"
 
 [[projects]]
-  digest = "1:6811ad355c0a0a602c8ae0bef0d999bdcbeedf05604ba7db382722182139f2fc"
-  name = "github.com/coreos-inc/vault-operator"
-  packages = [
-    "pkg/apis/vault/v1alpha1",
-    "pkg/client",
-    "pkg/generated/clientset/versioned",
-    "pkg/generated/clientset/versioned/scheme",
-    "pkg/generated/clientset/versioned/typed/vault/v1alpha1",
-    "pkg/generated/informers/externalversions/internalinterfaces",
-    "pkg/generated/informers/externalversions/vault/v1alpha1",
-    "pkg/generated/listers/vault/v1alpha1",
-    "pkg/util/k8sutil",
-    "pkg/util/probe",
-    "pkg/util/tlsutil",
-    "pkg/util/vaultutil",
-    "test/e2e/e2eutil",
-  ]
-  pruneopts = ""
-  revision = "43a1dd73183fd9d40b40e6f1e58b465c784d11a5"
-  version = "0.1.9"
-
-[[projects]]
   digest = "1:0af98a9f37993282a01fbb948a53bcf96053151ba61f9f00b762467099d83727"
   name = "github.com/coreos/etcd"
   packages = [
@@ -109,34 +87,6 @@
   pruneopts = ""
   revision = "85c37511b1293a530ab98c0118e117a30ad0fe26"
   version = "v0.8.3"
-
-[[projects]]
-  digest = "1:6811ad355c0a0a602c8ae0bef0d999bdcbeedf05604ba7db382722182139f2fc"
-  name = "github.com/coreos/vault-operator"
-  packages = [
-    "pkg/apis/vault/v1alpha1",
-    "pkg/client",
-    "pkg/generated/clientset/versioned",
-    "pkg/generated/clientset/versioned/scheme",
-    "pkg/generated/clientset/versioned/typed/vault/v1alpha1",
-    "pkg/generated/clientset/versioned/typed/vault/v1alpha1/fake",
-    "pkg/generated/informers/externalversions/internalinterfaces",
-    "pkg/generated/informers/externalversions/vault",
-    "pkg/generated/informers/externalversions/vault/v1alpha1",
-    "pkg/generated/listers/vault/v1alpha1",
-    "pkg/operator",
-    "pkg/util/k8sutil",
-    "pkg/util/probe",
-    "pkg/util/tlsutil",
-    "pkg/util/vaultutil",
-    "test/e2e/e2eutil",
-    "test/e2e/framework",
-    "test/e2e/upgradetest/framework",
-    "version",
-  ]
-  pruneopts = ""
-  revision = "43a1dd73183fd9d40b40e6f1e58b465c784d11a5"
-  version = "0.1.9"
 
 [[projects]]
   digest = "1:56c130d885a4aacae1dd9c7b71cfe39912c7ebc1ff7d2b46083c8812996dc43b"
@@ -833,25 +783,6 @@
     "github.com/coreos/etcd-operator/pkg/util/probe",
     "github.com/coreos/etcd-operator/pkg/util/retryutil",
     "github.com/coreos/etcd-operator/test/e2e/e2eutil",
-    "github.com/coreos/vault-operator/pkg/apis/vault/v1alpha1",
-    "github.com/coreos/vault-operator/pkg/client",
-    "github.com/coreos/vault-operator/pkg/generated/clientset/versioned",
-    "github.com/coreos/vault-operator/pkg/generated/clientset/versioned/scheme",
-    "github.com/coreos/vault-operator/pkg/generated/clientset/versioned/typed/vault/v1alpha1",
-    "github.com/coreos/vault-operator/pkg/generated/clientset/versioned/typed/vault/v1alpha1/fake",
-    "github.com/coreos/vault-operator/pkg/generated/informers/externalversions/internalinterfaces",
-    "github.com/coreos/vault-operator/pkg/generated/informers/externalversions/vault",
-    "github.com/coreos/vault-operator/pkg/generated/informers/externalversions/vault/v1alpha1",
-    "github.com/coreos/vault-operator/pkg/generated/listers/vault/v1alpha1",
-    "github.com/coreos/vault-operator/pkg/operator",
-    "github.com/coreos/vault-operator/pkg/util/k8sutil",
-    "github.com/coreos/vault-operator/pkg/util/probe",
-    "github.com/coreos/vault-operator/pkg/util/tlsutil",
-    "github.com/coreos/vault-operator/pkg/util/vaultutil",
-    "github.com/coreos/vault-operator/test/e2e/e2eutil",
-    "github.com/coreos/vault-operator/test/e2e/framework",
-    "github.com/coreos/vault-operator/test/e2e/upgradetest/framework",
-    "github.com/coreos/vault-operator/version",
     "github.com/golang/glog",
     "github.com/hashicorp/vault/api",
     "github.com/sirupsen/logrus",

--- a/example/deployment.yaml
+++ b/example/deployment.yaml
@@ -11,7 +11,7 @@ spec:
     spec:
       containers:
       - name: vault-operator
-        image: 239226036377.dkr.ecr.us-east-1.amazonaws.com/vault-operator:latest
+        image: quay.io/coreos/vault-operator:latest
         env:
         - name: MY_POD_NAMESPACE
           valueFrom:

--- a/pkg/operator/controller.go
+++ b/pkg/operator/controller.go
@@ -66,14 +66,11 @@ func (v *Vaults) run(ctx context.Context) {
 
 func (v *Vaults) onAddVault(obj interface{}) {
 	key, err := cache.MetaNamespaceKeyFunc(obj)
-	annotations := api.GetAnnotations()
 	if err != nil {
 		panic(err)
 	}
 	v.queue.Add(key)
-	logrus.Infof("Vault CR (%s) is created", annotations)
-	//annotations := api.GetAnnotations()
-	//logrus.Infof("Annotations: %s", annotations)
+	logrus.Infof("Vault CR (%s) is created", key)
 }
 
 func (v *Vaults) onUpdateVault(oldObj, newObj interface{}) {

--- a/pkg/util/k8sutil/vault.go
+++ b/pkg/util/k8sutil/vault.go
@@ -22,7 +22,6 @@ import (
 
 	api "github.com/coreos/vault-operator/pkg/apis/vault/v1alpha1"
 	"github.com/coreos/vault-operator/pkg/util/vaultutil"
-	"github.com/golang/glog"
 
 	etcdCRAPI "github.com/coreos/etcd-operator/pkg/apis/etcd/v1beta2"
 	etcdCRClient "github.com/coreos/etcd-operator/pkg/generated/clientset/versioned"
@@ -236,15 +235,12 @@ func statsdExporterContainer() v1.Container {
 // it and return no error. It is safe to retry on this function.
 func DeployVault(kubecli kubernetes.Interface, v *api.VaultService) error {
 	selector := LabelsForVault(v.GetName())
-	annotations := v.GetAnnotations()
-	glog.Warnf(annotations)
-	fmt.Printf(annotations)
 
 	podTempl := v1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   v.GetName(),
 			Labels: selector,
-			// Annotations: v.GetAnnotations()
+			Annotations: v.GetAnnotations(),
 		},
 		Spec: v1.PodSpec{
 			Containers: []v1.Container{vaultContainer(v), statsdExporterContainer()},


### PR DESCRIPTION
What this PR does/What is fixed:
Vault cluster pod lacked support for setting annotations as part of podSpec.

Fixed by adding support upon podSpec creation.

Annotations support is essential for allowing kube2iam or KIAM support to these pods in order to assume IAM roles in AWS EKS.