### PR TITLE
pkg/util: updated run cmd for official image

### DIFF
--- a/pkg/util/k8sutil/vault.go
+++ b/pkg/util/k8sutil/vault.go
@@ -146,9 +146,9 @@ func vaultContainer(v *api.VaultService) v1.Container {
 		Name:  "vault",
 		Image: fmt.Sprintf("%s:%s", v.Spec.BaseImage, v.Spec.Version),
 		Command: []string{
-			"/bin/vault",
-			"server",
-			"-config=" + VaultConfigPath,
+			"sh",
+			"-c",
+			"apk --no-cache add curl && setcap cap_ipc_lock=+ep $(readlink -f $(which vault)) && exec /bin/vault server -config=" + VaultConfigPath,
 		},
 		Env: []v1.EnvVar{
 			{


### PR DESCRIPTION
**What this PR does/What is fixed:**

This operator lacked support for the official vault image and the CoreOS repository images are lagging behind in versions.

Fixed by changing run command to use official DockerHub image with higher versions.

Signed-off-by: Saad Rana <saadrana219@gmail.com>